### PR TITLE
Fix circlci python install on build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     steps:
       - checkout
       - run: brew update
+      - run: brew unlink python@2
       - run: brew install shellcheck
       - run: shellcheck setup -e SC2039
       - run: ./setup


### PR DESCRIPTION
CircleCI changed their default python installation, we can fix the build step here to unlink python 2 so setup works.