### PR TITLE
Upgrade to new homebrew install method

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -11,6 +11,8 @@
   autocrlf = input
 [merge]
   ff = only
+[pull]
+  ff = only
 [fetch]
   prune = true
 [rebase]

--- a/os/linux
+++ b/os/linux
@@ -119,9 +119,7 @@ case $OS in
         sudo dnf groupinstall -y "C Development Tools and Libraries"
         dnf_add_mongo_repo
         sudo dnf -y install $FEDORA_PACKAGES
-        dnf_add_and_install_docker_ce
         fedora_enable_databases_on_restart
-        systemd_enable_docker_on_restart
         ;;
     Debian)
         fancy_echo "Installing packages using apt"

--- a/os/mac
+++ b/os/mac
@@ -19,6 +19,22 @@ install_homebrew() {
   fi
 }
 
+fix_previous_homebrew_if_necessary() {
+  HOMEBREW_LIBRARY=/usr/local/Homebrew/Library
+
+  [[ -f "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core/.git/shallow" ]] && HOMEBREW_CORE_SHALLOW=1
+  [[ -f "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask/.git/shallow" ]] && HOMEBREW_CASK_SHALLOW=1
+
+  if [[ -n $HOMEBREW_CORE_SHALLOW ]]; then
+    git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow
+  fi
+
+  if [[ -n $HOMEBREW_CASK_SHALLOW ]]; then
+    git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask" fetch --unshallow
+  fi
+}
+
+fix_previous_homebrew_if_necessary
 install_homebrew
 
 if brew list | grep -Fq brew-cask; then


### PR DESCRIPTION
I rushed in a fix for mac laptops earlier to accommodate a failing laptop setup run. This was due to homebrew upgrading to a new install system which no longer depends on ruby. This PR:

* Uses the new homebrew install method.
* Updates old installs by ensuring casks and homebrew are deep clones instead of shallow.
* Newer git requires a pull strategy defined in gitconfig
* Fedora has podman as a complete replacement for docker, so docker install not necessary.