### PR TITLE
Version Bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,16 @@ version: 2
 jobs:
   test-mac:
     macos:
-      xcode: "10.0.0"
+      xcode: 12.3.0
     steps:
       - checkout
       - run: brew update
-      - run: brew unlink python@2
       - run: brew install shellcheck
       - run: shellcheck setup -e SC2039
-      - run: ./setup
+      - run:
+          name: Run Setup Script
+          command: ./setup
+          no_output_timeout: 30m
   test-ubuntu:
     docker:
       - image: ubuntu:20.04
@@ -25,7 +27,7 @@ jobs:
       - run: ./setup
   test-fedora:
     docker:
-      - image: fedora:31
+      - image: fedora:33
     steps:
       - checkout
       - run: dnf -y install ShellCheck sudo util-linux-user

--- a/os/mac
+++ b/os/mac
@@ -37,7 +37,7 @@ fix_previous_homebrew_if_necessary() {
 fix_previous_homebrew_if_necessary
 install_homebrew
 
-if brew list | grep -Fq brew-cask; then
+if brew list --formula | grep -Fq brew-cask; then
   fancy_echo "Uninstalling old Homebrew-Cask ..."
   brew uninstall --force brew-cask
 fi


### PR DESCRIPTION
* MacOS version we were using was vastly out of date, which was causing circleci build failures. Bump MacOS version to `10.15.5`
* Bump to latest fedora version 33
* Modify deprecated list command.
* Increase `no_output_timeout` on mac due to 10m sometimes causing intermittent build failures.