### PR TITLE
fix(vimrc): moved set nocompatible lower down the file

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,4 +1,3 @@
-set nocompatible
 filetype plugin on
 syntax on
 
@@ -94,6 +93,7 @@ set ar
 set incsearch
 set hlsearch
 set vb t_vb=
+set nocompatible
 
 " Load matchit.vim, but only if the user hasn't installed a newer version.
 if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''


### PR DESCRIPTION
### Changes
Fixes the `set nocompatible` setting being ignored in the first line.

### Approach
`set nocompatible` is in the first line of the .vimrc file. I've seen a lot of tutorials set it in the first line. I haven't found a reason why it's being ignored. However, moving the setting lower down the file, the setting is no longer ignored.

Closes #26 