### PR TITLE
Fix issue cloning zsh-completion.

### DIFF
--- a/setup
+++ b/setup
@@ -145,7 +145,7 @@ fi
 # extended zsh completion
 if [ ! -d ~/.zsh/completion ]; then
   mkdir -p ~/.zsh
-  git clone git://github.com/zsh-users/zsh-completions.git ~/.zsh/completion
+  git clone https://github.com/zsh-users/zsh-completions.git ~/.zsh/completion
 fi
 
 if [ -f "$HOME/.laptop.user" ]; then


### PR DESCRIPTION
See: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Use https instead of git for unauthenticated repo.

Fixes #28 
