### PR TITLE
Add vim-repeat so that vim-surround commands are repeatable.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -8,6 +8,7 @@ call plug#begin('~/.vim/bundle')
   Plug 'ctrlpvim/ctrlp.vim'
   Plug 'tpope/vim-abolish' " e.g crc = CoeRce Camelcase
   Plug 'tpope/vim-surround'
+  Plug 'tpope/vim-repeat'
   Plug 'pbrisbin/vim-mkdir'
   Plug 'kana/vim-textobj-user'
   Plug 'janko-m/vim-test'


### PR DESCRIPTION
`vim-surround` does not interact well with the `.` command. `vim-repeat` ensures many Tim Pope plugins work with the `.` repeat command making for a more consistent experience.